### PR TITLE
Removing item prep call when creating the aggregate

### DIFF
--- a/src/Fluxera.Repository.EntityFrameworkCore/EntityFrameworkCoreRepository.cs
+++ b/src/Fluxera.Repository.EntityFrameworkCore/EntityFrameworkCoreRepository.cs
@@ -50,7 +50,6 @@
 		/// <inheritdoc />
 		protected override async Task AddAsync(TAggregateRoot item, CancellationToken cancellationToken)
 		{
-			this.PrepareItem(item, EntityState.Added);
 			await this.dbSet.AddAsync(item, cancellationToken).ConfigureAwait(false);
 
 			if(!this.options.IsUnitOfWorkEnabled)
@@ -63,11 +62,6 @@
 		protected override async Task AddRangeAsync(IEnumerable<TAggregateRoot> items, CancellationToken cancellationToken)
 		{
 			IList<TAggregateRoot> itemList = items.ToList();
-
-			foreach(TAggregateRoot item in itemList)
-			{
-				this.PrepareItem(item, EntityState.Added);
-			}
 
 			await this.dbSet.AddRangeAsync(itemList, cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
This PR resolves the issue where child entities don't save when the object is first pushed to the database as discussed in #105 .

I have removed the code to prep the items and the original tests still pass.  I have also pushed the packages to a private Nuget repository to check that the changes have the desired effect and work as expected.